### PR TITLE
move google apis to backend

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from contextlib import asynccontextmanager
 from db.database import init_db
-from routers import company_job, user_info
+from routers import company_job, user_info, google
 from fastapi.middleware.cors import CORSMiddleware
 
 @asynccontextmanager
@@ -13,6 +13,7 @@ app = FastAPI(lifespan=lifespan)
 
 app.include_router(company_job.router, prefix="/company")
 app.include_router(user_info.router, prefix="/user")
+app.include_router(google.router, prefix="/google")
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/app/routers/google.py
+++ b/backend/app/routers/google.py
@@ -1,0 +1,41 @@
+from fastapi import APIRouter, HTTPException, Request
+from services.google.email import getEmail 
+from services.google.sheets import createSheet, updateSheet
+
+router = APIRouter()
+
+@router.get("/get-email/{emailId}")
+async def getEmailId(req: Request, emailId: str):
+    try:
+        res = getEmail(req.headers, emailId)
+        success = {"status": "success"}
+        success.update(res)
+        return success
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    
+@router.post("/create-spreadsheet")
+async def createSpreadsheet(req: Request):
+    try:
+        data = await req.json()
+        res = createSheet(req.headers, data)
+        success = {"status": "success"}
+        success.update(res)
+        return success
+    except Exception as e:
+        print(e)
+        raise HTTPException(status_code=500, detail=str(e))
+    
+
+@router.post("/update-spreadsheet")
+async def updateSpreadsheet(req: Request):
+    try:
+        data = await req.json()
+        # hardcoding spreadsheetid for now
+        res = updateSheet(req.headers, data, "1p_NpdRVzrZ6V51ZN3WJbvVvW8wZI-rabOLEiyyD4_dw")
+        success = {"status": "success"}
+        success.update(res)
+        return success
+    except Exception as e:
+        print(e)
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/routers/google.py
+++ b/backend/app/routers/google.py
@@ -7,7 +7,7 @@ router = APIRouter()
 @router.get("/get-email/{emailId}")
 async def getEmailId(req: Request, emailId: str):
     try:
-        res = getEmail(req.headers, emailId)
+        res = await getEmail(req.headers, emailId)
         success = {"status": "success"}
         success.update(res)
         return success
@@ -18,7 +18,7 @@ async def getEmailId(req: Request, emailId: str):
 async def createSpreadsheet(req: Request):
     try:
         data = await req.json()
-        res = createSheet(req.headers, data)
+        res = await createSheet(req.headers, data)
         success = {"status": "success"}
         success.update(res)
         return success
@@ -32,7 +32,7 @@ async def updateSpreadsheet(req: Request):
     try:
         data = await req.json()
         # hardcoding spreadsheetid for now
-        res = updateSheet(req.headers, data, "1p_NpdRVzrZ6V51ZN3WJbvVvW8wZI-rabOLEiyyD4_dw")
+        res = await updateSheet(req.headers, data, "1p_NpdRVzrZ6V51ZN3WJbvVvW8wZI-rabOLEiyyD4_dw")
         success = {"status": "success"}
         success.update(res)
         return success

--- a/backend/app/services/clients/async_client.py
+++ b/backend/app/services/clients/async_client.py
@@ -1,0 +1,8 @@
+import httpx
+
+# Create a global async client
+client = httpx.AsyncClient()
+
+# Function to close the client
+async def close_client():
+    await client.aclose()

--- a/backend/app/services/google/email.py
+++ b/backend/app/services/google/email.py
@@ -1,0 +1,18 @@
+import requests
+
+def getEmail(headers: dict, emailId: str):
+    try:
+        auth_header = headers.get("authorization")
+        if not auth_header:
+            raise ValueError("Missing authorization header")
+        
+        headerValues = {
+            "Authorization": auth_header,
+            "Content-Type": "application/json",
+        }
+        response = requests.get(f'https://gmail.googleapis.com/gmail/v1/users/me/messages/{emailId}?format=full', headers=headerValues)
+        if response.status_code == 200:
+            return response.json()
+    except requests.exceptions.HTTPError as error:
+        print(f"An error occurred: {error}")
+        return error

--- a/backend/app/services/google/email.py
+++ b/backend/app/services/google/email.py
@@ -1,6 +1,6 @@
-import requests
+from services.clients.async_client import client
 
-def getEmail(headers: dict, emailId: str):
+async def getEmail(headers: dict, emailId: str):
     try:
         auth_header = headers.get("authorization")
         if not auth_header:
@@ -10,9 +10,9 @@ def getEmail(headers: dict, emailId: str):
             "Authorization": auth_header,
             "Content-Type": "application/json",
         }
-        response = requests.get(f'https://gmail.googleapis.com/gmail/v1/users/me/messages/{emailId}?format=full', headers=headerValues)
+        response = await client.get(f'https://gmail.googleapis.com/gmail/v1/users/me/messages/{emailId}?format=full', headers=headerValues)
         if response.status_code == 200:
             return response.json()
-    except requests.exceptions.HTTPError as error:
+    except Exception as error:
         print(f"An error occurred: {error}")
         return error

--- a/backend/app/services/google/sheets.py
+++ b/backend/app/services/google/sheets.py
@@ -1,0 +1,55 @@
+import requests 
+
+def createSheet(headers: dict, body: dict) -> dict:
+    try:
+        auth_header = headers.get("authorization")
+        if not auth_header:
+            raise ValueError("Missing authorization header")
+        
+        headerValues = {
+            "Authorization": auth_header,
+            "Content-Type": "application/json",
+        }
+        response = requests.post("https://sheets.googleapis.com/v4/spreadsheets", headers=headerValues, json=body)
+        if response.status_code == 200:
+            print(response)
+            return response.json()
+        
+        return {"error": f"Unexpected status {response.status_code}", "details": response.text}
+    except Exception as error:
+        print(f"An error occurred: {error}")
+        return {"error": str(error)}
+
+
+
+# const response = await fetch(
+#           `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values:batchUpdate`,
+#           {
+#               method: "POST",
+#               headers: {
+#                   "Content-Type": "application/json",
+#                   Authorization: `Bearer ${token}`
+#               },
+#               body: JSON.stringify(requestBody)
+#           }
+#       );
+
+def updateSheet(headers: dict, body: dict, spreadsheetId: str) -> dict:
+    try:
+        auth_header = headers.get("authorization")
+        if not auth_header:
+            raise ValueError("Missing authorization header")
+        
+        headerValues = {
+            "Authorization": auth_header,
+            "Content-Type": "application/json",
+        }
+        response = requests.post(f"https://sheets.googleapis.com/v4/spreadsheets/{spreadsheetId}/values:batchUpdate", headers=headerValues, json=body)
+        if response.status_code == 200:
+            print(response)
+            return response.json()
+        
+        return {"error": f"Unexpected status {response.status_code}", "details": response.text}
+    except Exception as error:
+        print(f"An error occurred: {error}")
+        return {"error": str(error)}

--- a/backend/app/services/google/sheets.py
+++ b/backend/app/services/google/sheets.py
@@ -1,6 +1,6 @@
-import requests 
+from services.clients.async_client import client
 
-def createSheet(headers: dict, body: dict) -> dict:
+async def createSheet(headers: dict, body: dict) -> dict:
     try:
         auth_header = headers.get("authorization")
         if not auth_header:
@@ -10,7 +10,8 @@ def createSheet(headers: dict, body: dict) -> dict:
             "Authorization": auth_header,
             "Content-Type": "application/json",
         }
-        response = requests.post("https://sheets.googleapis.com/v4/spreadsheets", headers=headerValues, json=body)
+
+        response = await client.post("https://sheets.googleapis.com/v4/spreadsheets", headers=headerValues, json=body)
         if response.status_code == 200:
             print(response)
             return response.json()
@@ -20,21 +21,7 @@ def createSheet(headers: dict, body: dict) -> dict:
         print(f"An error occurred: {error}")
         return {"error": str(error)}
 
-
-
-# const response = await fetch(
-#           `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values:batchUpdate`,
-#           {
-#               method: "POST",
-#               headers: {
-#                   "Content-Type": "application/json",
-#                   Authorization: `Bearer ${token}`
-#               },
-#               body: JSON.stringify(requestBody)
-#           }
-#       );
-
-def updateSheet(headers: dict, body: dict, spreadsheetId: str) -> dict:
+async def updateSheet(headers: dict, body: dict, spreadsheetId: str) -> dict:
     try:
         auth_header = headers.get("authorization")
         if not auth_header:
@@ -44,7 +31,7 @@ def updateSheet(headers: dict, body: dict, spreadsheetId: str) -> dict:
             "Authorization": auth_header,
             "Content-Type": "application/json",
         }
-        response = requests.post(f"https://sheets.googleapis.com/v4/spreadsheets/{spreadsheetId}/values:batchUpdate", headers=headerValues, json=body)
+        response = await client.post(f"https://sheets.googleapis.com/v4/spreadsheets/{spreadsheetId}/values:batchUpdate", headers=headerValues, json=body)
         if response.status_code == 200:
             print(response)
             return response.json()

--- a/chrome_extension/src/components/ContentScript.tsx
+++ b/chrome_extension/src/components/ContentScript.tsx
@@ -171,7 +171,7 @@ const handleFetchEmail = async (emailId: string) => {
   try {
     const token = await getAuthToken();
     const emailDetailsResponse = await fetch(
-      `https://gmail.googleapis.com/gmail/v1/users/me/messages/${emailId}?format=full`,
+      `http://127.0.0.1:8080/google/get-email/${emailId}`,
       { headers: { Authorization: `Bearer ${token}` } }
     );
     const emailData = await emailDetailsResponse.json();

--- a/chrome_extension/src/components/MainFrame.tsx
+++ b/chrome_extension/src/components/MainFrame.tsx
@@ -92,10 +92,10 @@ const generateTableRequest = async (emailDetails: String[]): Promise<JobResults 
 const createNewSpreadsheet = async (token: string): Promise<SpreadSheet | null> => {
   try {
       const requestBody = {
-          properties: { title: "JobHunting" }
+          properties: { title: "JobHuntingTest" }
       };
 
-      const response = await fetch('https://sheets.googleapis.com/v4/spreadsheets', {
+      const response = await fetch('http://127.0.0.1:8080/google/create-spreadsheet', {
           method: "POST",
           headers: {
               "Content-Type": "application/json",
@@ -237,7 +237,7 @@ function MainFrame() {
     try {
       const token = await getAuthToken();
       const spreadsheetUpdateResponse = await fetch(
-        `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values:batchUpdate`,
+        'http://127.0.0.1:8080/google/update-spreadsheet',
         {
           method: "POST",
           headers: {
@@ -251,7 +251,7 @@ function MainFrame() {
                 range: "A1:B1",
                 majorDimension: "ROWS",
                 values: [
-                  ["hi","JobHunter"]
+                  ["hi","Hunters"]
                 ]
               }
             ],


### PR DESCRIPTION
The `/google/*` routes are purely for testing. I don't imagine we'll need these in our actual workflows