### PR TITLE
Add Auth verification for Google Token

### DIFF
--- a/backend/app/auth/verification.py
+++ b/backend/app/auth/verification.py
@@ -1,6 +1,7 @@
 from fastapi import HTTPException, Security
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from services.clients.async_client import client
+import httpx 
 
 security = HTTPBearer() 
 
@@ -9,7 +10,10 @@ async def verify_google_token(credentials: HTTPAuthorizationCredentials = Securi
     token = credentials.credentials
     if not token:
         raise HTTPException(status_code=401, detail="Token required")
-    response = await client.get(f'https://oauth2.googleapis.com/tokeninfo?access_token={token}')
-    if not response:
+    try:
+        response = await client.get(f'https://oauth2.googleapis.com/tokeninfo?access_token={token}')
+        response.raise_for_status()
+    except httpx.HTTPStatusError as e:
         raise HTTPException(status_code=401, detail="Invalid token")
+    
     return response.json()

--- a/backend/app/auth/verification.py
+++ b/backend/app/auth/verification.py
@@ -6,15 +6,10 @@ security = HTTPBearer()
 
 
 async def verify_google_token(credentials: HTTPAuthorizationCredentials = Security(security)):
-    print(credentials)
     token = credentials.credentials
     if not token:
         raise HTTPException(status_code=401, detail="Token required")
-    print("hello")
     response = await client.get(f'https://oauth2.googleapis.com/tokeninfo?access_token={token}')
-    print("hello0")
     if not response:
         raise HTTPException(status_code=401, detail="Invalid token")
-    print("hello1")
-    print(response)
     return response.json()

--- a/backend/app/auth/verification.py
+++ b/backend/app/auth/verification.py
@@ -1,0 +1,20 @@
+from fastapi import HTTPException, Security
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from services.clients.async_client import client
+
+security = HTTPBearer() 
+
+
+async def verify_google_token(credentials: HTTPAuthorizationCredentials = Security(security)):
+    print(credentials)
+    token = credentials.credentials
+    if not token:
+        raise HTTPException(status_code=401, detail="Token required")
+    print("hello")
+    response = await client.get(f'https://oauth2.googleapis.com/tokeninfo?access_token={token}')
+    print("hello0")
+    if not response:
+        raise HTTPException(status_code=401, detail="Invalid token")
+    print("hello1")
+    print(response)
+    return response.json()

--- a/backend/app/routers/audio_response.py
+++ b/backend/app/routers/audio_response.py
@@ -1,10 +1,10 @@
 # audio_feedback_router.py
 import os
-import tempfile
-from fastapi import APIRouter, UploadFile, File, HTTPException
+from fastapi import APIRouter, UploadFile, File, HTTPException, Depends
 from dotenv import load_dotenv
 from openai import OpenAI  # Using the new client interface
 from services.interview.audio_feedback_service import process_audio_feedback
+from auth.verification import verify_google_token
 
 router = APIRouter()
 load_dotenv()
@@ -13,7 +13,7 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 client = OpenAI(api_key=OPENAI_API_KEY)
 
 @router.post("/audio-feedback")
-async def audio_feedback(audio_response: UploadFile = File(...)):
+async def audio_feedback(audio_response: UploadFile = File(...), auth_data: dict = Depends(verify_google_token)):
     try:
         # Read the uploaded audio content
         content = await audio_response.read()

--- a/backend/app/routers/company_job.py
+++ b/backend/app/routers/company_job.py
@@ -1,29 +1,29 @@
-import json
 from services.job import job_url_service
-from services.tools.web_scraper_tool import WebScrapperTool
-from models.create_table import JobInformation
-from fastapi import APIRouter, HTTPException, Header, Body
-from services.clients.perplexity_client import PerplexityClient 
+from fastapi import APIRouter, HTTPException, Depends, Request
 from config.keys import PERPLEXITY_API_KEY
 from models.email_summary import GPT_Email_Summary_Response, Status
-from utils.helpers import string_to_json
 from services.summary import email_summary_service
 from services.job import job_status_service
 from config.logger import logger
 from services.email import email_service
+from auth.verification import verify_google_token
 
 # set up logger 
 router = APIRouter() 
 
 @router.get("/email-summary")
-async def get_summary_email(email: str):
+async def get_summary_email(req: Request, auth_data: dict = Depends(verify_google_token)):
+    body = await req.json()
+    email = body.get("email")
     return await email_summary_service.email_summary(email)
 
 
 @router.post("/company-job-info-crew-ai")
-async def get_company_job_info( email_id: str = Body(...), authorization: str = Header(...) ):
+async def get_company_job_info(req: Request, auth_data: dict = Depends(verify_google_token)):
     logger.info("INFO CREW AI CALLED")
-    
+    body = await req.json()
+    email_id = body.get("email_id")
+    authorization = req.headers.get("authorization")
     # Step 1: Get email content
     email_response = await email_service.get_email(authorization, email_id)
     user_id = email_response['payload']['headers'][0]['value']
@@ -44,13 +44,15 @@ async def get_company_job_info( email_id: str = Body(...), authorization: str = 
             raise HTTPException(status_code=500, detail="Response validation failed")
         
 @router.post("/company-job-url-crew-ai")
-async def get_company_job_url(user_id: str = Body(...), job_post_url: str = Body(...), authorization: str = Header(...)):
+async def get_company_job_url(req: Request, auth_data: dict = Depends(verify_google_token)):
     logger.info("INFO CREW AI CALLED")
-
+    body = await req.json()
+    job_post_url = body.get("job_post_url")
+    user_id = auth_data.get("email")
     scraped_response = job_url_service.get_job_link_info(job_post_url)
     # Use job posting content as the "email"
     summary_json: GPT_Email_Summary_Response = await email_summary_service.email_summary(scraped_response)
 
     # Assume the user is in the Interviewing phase
-    await job_status_service.handle_in_review_or_interview(summary_json,user_id, authorization)
+    await job_status_service.handle_in_review_or_interview(summary_json, user_id, req.headers.get("authorization"))
     return {"message": "Job info successfully updated"}

--- a/backend/app/routers/upload_router.py
+++ b/backend/app/routers/upload_router.py
@@ -1,21 +1,18 @@
 # upload_router.py
-import base64
-from fastapi import APIRouter, UploadFile, File, Form, HTTPException
+from fastapi import APIRouter, UploadFile, File, HTTPException, Depends
 from services.interview.insert_resume import insert_resume
 from services.interview.resume_parser import extract_resume_text
-from services.interview.summarize import summarize_resume, summarize_job_details  # Your summarization service
-from services.interview.extract_job import extract_job_description_trafilatura
-from services.interview.generate_question import generate_interview_question
 from utils.text_cleaner import clean_resume_text
+from auth.verification import verify_google_token
 
 router = APIRouter()
 
 @router.post("/upload-resume")
 async def upload_resume(
     resume: UploadFile = File(...),
-    userId: str = Form(...),
+    auth_data: dict = Depends(verify_google_token)
 ):
-
+    userId = auth_data.get("email")
     allowed_extensions = {"pdf", "doc", "docx"}
     filename = resume.filename
     extension = filename.split('.')[-1].lower()

--- a/chrome_extension/src/App.tsx
+++ b/chrome_extension/src/App.tsx
@@ -9,7 +9,7 @@ const getUserInfo = async () => {
   const userEmail = await getUserEmail();
   const token = await getAuthToken();
   const userInfo = await fetch(
-      `http://127.0.0.1:8080/user/get-user-excel?user_id=${userEmail}`,
+      `http://127.0.0.1:8080/user/get-user-excel`,
       {
           method: "GET",
           headers: {

--- a/chrome_extension/src/App.tsx
+++ b/chrome_extension/src/App.tsx
@@ -6,7 +6,6 @@ import { useEffect, useState } from 'react';
 import { UserInfo } from './helpers/types';
 
 const getUserInfo = async () => {
-  const userEmail = await getUserEmail();
   const token = await getAuthToken();
   const userInfo = await fetch(
       `http://127.0.0.1:8080/user/get-user-excel`,

--- a/chrome_extension/src/components/ContentScript.tsx
+++ b/chrome_extension/src/components/ContentScript.tsx
@@ -6,18 +6,23 @@ console.log("Content script loaded as module.");
 const handleFetchEmail = async (emailId: string) => {
   try {
     const token = await getAuthToken();
-
     const spreadsheetUpdateResponse = await fetch(
         'http://127.0.0.1:8080/company/company-job-info-crew-ai',
         {
             method: "POST",
             headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`
             },
-            body: JSON.stringify(emailId)
+            body: JSON.stringify({
+              "email_id": emailId
+            })
         }
     );
+
+    if (!spreadsheetUpdateResponse.ok) {
+      throw Error(await spreadsheetUpdateResponse.text());
+    }
   } catch (error: any) {
     console.error("Error fetching email summary:", error.message);
   }

--- a/chrome_extension/src/components/Overview.tsx
+++ b/chrome_extension/src/components/Overview.tsx
@@ -25,7 +25,7 @@ function Overview() {
 
         {/* Button that links to job spreadsheet */}
         <div className="flex flex-col items-start gap-2">
-        {userInfo &&
+        {userInfo && userInfo.excel_id &&
           <>
             <a href={`https://docs.google.com/spreadsheets/d/${userInfo.excel_id}/edit?gid=0#gid=0`} 
             target="_blank"
@@ -43,6 +43,13 @@ function Overview() {
                 This will create a new Job Sheet if you haven't logged in before.
             </span>
           </> 
+        }
+        {(!userInfo || !userInfo.excel_id) && 
+        <>
+          <span className="flex text-sm text-gray-500 italic">
+              Experiencing some problems with the server. Try again
+          </span>
+        </>
         }
         </div>
       </div>

--- a/chrome_extension/src/components/UploadJobLink.tsx
+++ b/chrome_extension/src/components/UploadJobLink.tsx
@@ -3,17 +3,15 @@ import LinkIcon from '@mui/icons-material/Link';
 import { Button } from '@mui/material';
 import { useState } from 'react';
 import { getAuthToken } from '../chrome/utils';
-import { useRootContext } from '../context/RootContext';
 
-const submitURL = async (url: string, user_id: string) => {
+const submitURL = async (url: string) => {
   const token = await getAuthToken();
-  const userInfo = await fetch(
+  await fetch(
       `http://127.0.0.1:8080/company/company-job-url-crew-ai`,
       {
           method: "POST",
           body: JSON.stringify({
-            "job_post_url": url,
-            "user_id": user_id
+            "job_post_url": url
           }),
           headers: {
               "Content-Type": 'application/json',
@@ -21,24 +19,15 @@ const submitURL = async (url: string, user_id: string) => {
           },
       }
   );
-
-  const userObject = await userInfo.json();
-  console.log("userObject", userObject);
-  return userObject;
 }
 
 function UploadJobLink() {
     const [inputValue, setInputValue] = useState('');
-    const userInfo = useRootContext();
-    const handleSubmit = (e: React.FormEvent) => {
+
+    const handleSubmit = (e: React.FormEvent) =>{
         console.log('Submitting...');
         e.preventDefault();
-        console.log('Submitted:', inputValue);
-        if (userInfo) {
-          submitURL(inputValue, userInfo.user_id);
-        } else {
-          console.log('User info invalid; Skipping');
-        }
+        submitURL(inputValue);
         setInputValue('');
     };
 
@@ -73,7 +62,7 @@ function UploadJobLink() {
                       <span>Upload</span>
                   </Button>
                 </form>
-            </div>
+          </div>
         </div>
     );
 }

--- a/chrome_extension/src/components/UploadResume.tsx
+++ b/chrome_extension/src/components/UploadResume.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import DescriptionIcon from '@mui/icons-material/Description';
-import { getUserEmail } from '../chrome/utils';
 import { Button } from '@mui/material';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import FileUploadInput from './FileUploadButton';
+import { getAuthToken } from '../chrome/utils';
 
 function UploadResume() {
   const [resume, setResume] = useState<File | null>(null);
@@ -28,12 +28,15 @@ function UploadResume() {
     setLoading(true);
     const formData = new FormData();
     formData.append('resume', resume);
-    formData.append('userId', await getUserEmail());
 
     try {
+      const token = await getAuthToken();
       const response = await fetch('http://127.0.0.1:8080/upload/upload-resume', {
         method: 'POST',
         body: formData,
+        headers: {
+            "Authorization": `Bearer ${token}`
+        }
       });
 
       if (!response.ok) {


### PR DESCRIPTION
Verifying the google auth token by calling `https://oauth2.googleapis.com/tokeninfo?access_token={token}`. If no response, then client sent an invalid token. If response, user is valid. 

We no longer need to pass in user id for some routes and can get this directly from the google token.

Note: Some of the routes need to be changed to use `Request` instead of the automatic parsing of body args.

